### PR TITLE
Update utils.js where now it will check for the separator character used on the path string

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ class Mp32Wav {
     this._output_file_name = this._input_file_name.toString().replace(/\.mp3/i, '')
   }
 
-  async exec({returnFloat) {
+  async exec({returnFloat}) {
 
     try {
       const mp3DecodeRes = await this.decodeMp3(this._input_file_path)

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ class Mp32Wav {
 
     try {
       const mp3DecodeRes = await this.decodeMp3(this._input_file_path)
-      if (returnFloat) mp3DecodeRes.float = returnFloat
+      if ( returnFloat ) mp3DecodeRes.float = returnFloat
       const wavPath = this.saveForWav(mp3DecodeRes.data, this._output_dir, this._output_file_name, mp3DecodeRes.sampleRate, mp3DecodeRes.channels, mp3DecodeRes.float)
       console.log(`Mp32Wav convert to wav file successfully, saving on: ${wavPath}`)
     } catch (err) {

--- a/index.js
+++ b/index.js
@@ -19,10 +19,11 @@ class Mp32Wav {
     this._output_file_name = this._input_file_name.toString().replace(/\.mp3/i, '')
   }
 
-  async exec() {
+  async exec({returnFloat) {
 
     try {
       const mp3DecodeRes = await this.decodeMp3(this._input_file_path)
+      if (returnFloat) mp3DecodeRes.float = returnFloat
       const wavPath = this.saveForWav(mp3DecodeRes.data, this._output_dir, this._output_file_name, mp3DecodeRes.sampleRate, mp3DecodeRes.channels, mp3DecodeRes.float)
       console.log(`Mp32Wav convert to wav file successfully, saving on: ${wavPath}`)
     } catch (err) {

--- a/libs/utils.js
+++ b/libs/utils.js
@@ -134,10 +134,12 @@ module.exports = {
   ensurePathExists(dirPath) {
 
     if (!dirPath) return
-    let splitDirPath = dirPath.split('/')
+    let separatorCharacter = '/'
+    if (dirPath.includes('\\') separatorCharacter = '\\'
+    let splitDirPath = dirPath.split(separatorCharacter)
     if (splitDirPath.length > 1) {
       splitDirPath.pop()
-      splitDirPath = splitDirPath.join('/')
+      splitDirPath = splitDirPath.join(separatorCharacter)
     }
     if (!fs.pathExistsSync(splitDirPath)) {
       fs.mkdirpSync(splitDirPath)

--- a/libs/utils.js
+++ b/libs/utils.js
@@ -135,7 +135,7 @@ module.exports = {
 
     if (!dirPath) return
     let separatorCharacter = '/'
-    if (dirPath.includes('\\') separatorCharacter = '\\'
+    if (dirPath.includes('\\')) separatorCharacter = '\\'
     let splitDirPath = dirPath.split(separatorCharacter)
     if (splitDirPath.length > 1) {
       splitDirPath.pop()


### PR DESCRIPTION
Before it was using "/" to split the path string. 
This was returning an error where the path was an array.
This was due to the fact that Windows uses "\\" to separate the folders.

I changed the fucntion "ensurePathExist" to check if the path has "\\" as separator character. If so, it'll use "\\" as separator character.